### PR TITLE
Fix case sensitivity of module JSV

### DIFF
--- a/lib/jsprim.js
+++ b/lib/jsprim.js
@@ -245,7 +245,7 @@ function parseDateTime(str)
 function validateJsonObjectJSV(schema, input)
 {
 	if (!mod_jsv)
-		mod_jsv = require('jsv');
+		mod_jsv = require('JSV');
 
 	var env = mod_jsv.JSV.createEnvironment();
 	var report = env.validate(input, schema);


### PR DESCRIPTION
On strict case-sensitive environments like RedHat, loading module ‘jsv’
fails since I have upper-case ‘JSV’ installed, as defined by the npm
package https://www.npmjs.org/package/JSV
