### PR TITLE
Upgrading upstream dep to avoid vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"dependencies": {
 		"assert-plus": "1.0.0",
 		"extsprintf": "1.3.0",
-		"json-schema": "0.2.3",
+		"json-schema": "0.2.5",
 		"verror": "1.10.0"
 	},
 	"engines": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"dependencies": {
 		"assert-plus": "1.0.0",
 		"extsprintf": "1.3.0",
-		"json-schema": "0.2.3",
+		"json-schema": "^0.4.0",
 		"verror": "1.10.0"
 	},
 	"engines": [

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
 		"url": "git://github.com/joyent/node-jsprim.git"
 	},
 	"dependencies": {
-		"assert-plus": "1.0.0",
-		"extsprintf": "1.3.0",
-		"json-schema": "0.2.5",
-		"verror": "1.10.0"
+		"assert-plus": "^1.0.0",
+		"extsprintf": "^1.3.0",
+		"json-schema": "^0.2.5",
+		"verror": "^1.10.0"
 	},
 	"engines": [
 		"node >=0.6.0"


### PR DESCRIPTION
Prototype polution: https://security.snyk.io/vuln/SNYK-JS-JSONSCHEMA-1920922
Incorporates #27 since it's got a better representation for the remaining deps.

> Thus closes #27 when merged.