### PR TITLE
joyent/node-jsprim#33 json-schema dep is vulnerable to prototype pollution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,14 @@
 
 None yet.
 
+## v2.0.2 (2021-11-16)
+
+* #30 json-schema dep is vulnerable to prototype pollution
+      See also https://security.snyk.io/vuln/SNYK-JS-JSONSCHEMA-1920922
+
+## v2.0.1 (2021-11-03)
+
+* Remove use of `git://` URLs.
 ## v2.0.0 (2017-10-25)
 
 Major bump due to a change in the semantics of `deepEqual`. Code that relies on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsprim",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "utilities for primitive JavaScript types",
 	"main": "./lib/jsprim.js",
 	"repository": {
@@ -10,7 +10,7 @@
 	"dependencies": {
 		"assert-plus": "1.0.0",
 		"extsprintf": "1.3.0",
-		"json-schema": "0.2.3",
+		"json-schema": "0.4.0",
 		"verror": "1.10.0"
 	},
 	"engines": [


### PR DESCRIPTION
Test results in #33.

Also fixes:

* #27
* #30
* #32
